### PR TITLE
Settings Refactor

### DIFF
--- a/scripts/assassination.py
+++ b/scripts/assassination.py
@@ -101,7 +101,7 @@ test_traits = artifact.Artifact(test_spec, test_class, trait_dict={
 })
 
 # Set up settings.
-test_cycle = settings.AssassinationCycle('just', 'just')
+test_cycle = settings.AssassinationCycle()
 test_settings = settings.Settings(test_cycle, response_time=.5, duration=300,
                                   finisher_threshold=4)
 

--- a/scripts/subtlety.py
+++ b/scripts/subtlety.py
@@ -9,6 +9,7 @@ sys.path.append(path.abspath(path.join(path.dirname(__file__), '..')))
 
 from shadowcraft.calcs.rogue.Aldriana import AldrianasRogueDamageCalculator
 from shadowcraft.calcs.rogue.Aldriana import settings
+from shadowcraft.calcs.rogue.Aldriana import settings_data
 
 from shadowcraft.objects import buffs
 from shadowcraft.objects import race
@@ -116,12 +117,8 @@ test_traits = artifact.Artifact(test_spec, test_class, trait_dict={
 })
 
 # Set up settings.
-test_cycle = settings.SubtletyCycle(cp_builder='backstab',
-                                    dance_finishers_allowed=True,
-                                    positional_uptime=1.
-    )
-test_settings = settings.Settings(test_cycle, response_time=.5, duration=300,
-                                 adv_params="", is_demon=False, num_boss_adds=0, marked_for_death_resets=0.0)
+test_cycle = settings.SubtletyCycle()
+test_settings = settings.Settings(test_cycle)
 
 # Build a DPS object.
 calculator = AldrianasRogueDamageCalculator(test_stats, test_talents, test_traits, test_buffs, test_race, test_spec, test_settings, test_level)
@@ -131,8 +128,6 @@ print(str(test_stats.get_character_stats(test_race)))
 # Compute DPS Breakdown.
 dps_breakdown = calculator.get_dps_breakdown()
 total_dps = sum(entry[1] for entry in list(dps_breakdown.items()))
-
-print(str(calculator.shadow_blades_uptime))
 
 # Compute EP values.
 ep_values = calculator.get_ep(baseline_dps=total_dps)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name='ShadowCraft-Engine',
     url='http://github.com/ShadowCraft/ShadowCraft-Engine/',
-    version='7.1.5',
+    version='7.2.0',
     packages=[
         'shadowcraft',
         'shadowcraft.calcs',

--- a/shadowcraft/calcs/__init__.py
+++ b/shadowcraft/calcs/__init__.py
@@ -621,7 +621,7 @@ class DamageCalculator(object):
         # damage value.
         return damage * self.armor_mitigation_multiplier(armor)
 
-    def melee_hit_chance(self, base_miss_chance, dodgeable, parryable, weapon_type, blockable=False):
+    def melee_hit_chance(self, base_miss_chance, dodgeable, parryable, blockable=False):
         miss_chance = base_miss_chance
 
         if dodgeable:
@@ -642,45 +642,41 @@ class DamageCalculator(object):
         return (1 - (miss_chance + dodge_chance + parry_chance)) * (1 - block_chance)
 
     def melee_spells_hit_chance(self, bonus_hit=0):
-        hit_chance = self.melee_hit_chance(self.base_one_hand_miss_rate, dodgeable=False, parryable=False, weapon_type=None)
+        hit_chance = self.melee_hit_chance(self.base_one_hand_miss_rate, dodgeable=False, parryable=False)
         return hit_chance
 
-    def one_hand_melee_hit_chance(self, dodgeable=False, parryable=False, weapon=None, blockable=False):
+    def one_hand_melee_hit_chance(self, dodgeable=False, parryable=False, blockable=False):
         # Most attacks by DPS aren't parryable due to positional negation. But
         # if you ever want to attacking from the front, you can just set that
         # to True.
-        if weapon == None:
-            weapon = self.stats.mh
-        hit_chance = self.melee_hit_chance(self.base_one_hand_miss_rate, dodgeable, parryable, weapon.type, blockable)
+        hit_chance = self.melee_hit_chance(self.base_one_hand_miss_rate, dodgeable, parryable, blockable)
         return hit_chance
 
-    def off_hand_melee_hit_chance(self, dodgeable=False, parryable=False, weapon=None, bonus_hit=0):
+    def off_hand_melee_hit_chance(self, dodgeable=False, parryable=False, bonus_hit=0):
         # Most attacks by DPS aren't parryable due to positional negation. But
         # if you ever want to attacking from the front, you can just set that
         # to True.
-        if weapon == None:
-            weapon = self.stats.oh
-        hit_chance = self.melee_hit_chance(self.base_one_hand_miss_rate, dodgeable, parryable, weapon.type)
+        hit_chance = self.melee_hit_chance(self.base_one_hand_miss_rate, dodgeable, parryable)
         return hit_chance
 
     def dual_wield_mh_hit_chance(self, dodgeable=False, parryable=False, dw_miss=None):
         # Most attacks by DPS aren't parryable due to positional negation. But
         # if you ever want to attacking from the front, you can just set that
         # to True.
-        hit_chance = self.dual_wield_hit_chance(dodgeable, parryable, self.stats.mh.type, dw_miss=dw_miss)
+        hit_chance = self.dual_wield_hit_chance(dodgeable, parryable, dw_miss=dw_miss)
         return hit_chance
 
     def dual_wield_oh_hit_chance(self, dodgeable=False, parryable=False, dw_miss=None):
         # Most attacks by DPS aren't parryable due to positional negation. But
         # if you ever want to attacking from the front, you can just set that
         # to True.
-        hit_chance = self.dual_wield_hit_chance(dodgeable, parryable, self.stats.oh.type, dw_miss=dw_miss)
+        hit_chance = self.dual_wield_hit_chance(dodgeable, parryable, dw_miss=dw_miss)
         return hit_chance
 
-    def dual_wield_hit_chance(self, dodgeable, parryable, weapon_type, dw_miss=None):
+    def dual_wield_hit_chance(self, dodgeable, parryable, dw_miss=None):
         if not dw_miss:
             dw_miss = self.base_dw_miss_rate
-        hit_chance = self.melee_hit_chance(dw_miss, dodgeable, parryable, weapon_type)
+        hit_chance = self.melee_hit_chance(dw_miss, dodgeable, parryable)
         return hit_chance
 
     def buff_melee_crit(self):

--- a/shadowcraft/calcs/rogue/Aldriana/__init__.py
+++ b/shadowcraft/calcs/rogue/Aldriana/__init__.py
@@ -217,14 +217,6 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
             if boost['stat'] in self.base_stats:
                 self.base_stats[boost['stat']] += boost['value'] * boost['duration'] * 1.0 / (boost['cooldown'] + self.settings.response_time)
 
-        if self.stats.procs.virmens_bite:
-            getattr(self.stats.procs, 'virmens_bite').icd = self.settings.duration
-        if self.stats.procs.virmens_bite_prepot:
-            getattr(self.stats.procs, 'virmens_bite_prepot').icd = self.settings.duration
-        if self.stats.procs.draenic_agi_pot:
-            getattr(self.stats.procs, 'draenic_agi_pot').icd = self.settings.duration
-        if self.stats.procs.draenic_agi_prepot:
-            getattr(self.stats.procs, 'draenic_agi_prepot').icd = self.settings.duration
         if self.stats.procs.prolonged_power_pot:
             self.stats.procs.prolonged_power_pot.icd = self.settings.duration
         if self.stats.procs.prolonged_power_prepot:

--- a/shadowcraft/calcs/rogue/Aldriana/__init__.py
+++ b/shadowcraft/calcs/rogue/Aldriana/__init__.py
@@ -617,25 +617,6 @@ class AldrianasRogueDamageCalculator(RogueDamageCalculator):
             elif proc.stat == 'extra_weapon_damage':
                 weapon_damage_procs.append(proc)
 
-        #calculate weapon procs
-        weapon_enchants = set([])
-        for hand, enchant in [(x, y) for x in ('mh', 'oh') for y in ('dancing_steel', 'mark_of_the_frostwolf',
-                                                                     'mark_of_the_shattered_hand', 'mark_of_the_thunderlord',
-                                                                     'mark_of_the_bleeding_hollow', 'mark_of_warsong')]:
-            proc = getattr(getattr(self.stats, hand), enchant)
-            if proc:
-                setattr(proc, '_'.join((hand, 'only')), True)
-                if (proc.stat in current_stats or proc.stat == 'stats'):
-                    if proc.is_real_ppm():
-                        active_procs_rppm.append(proc)
-                    else:
-                        if proc.icd:
-                            active_procs_icd.append(proc)
-                        else:
-                            active_procs_no_icd.append(proc)
-                elif enchant in ('mark_of_the_shattered_hand', ):
-                    damage_procs.append(proc)
-
         static_proc_stats = {
             'str': 0,
             'agi': 0,

--- a/shadowcraft/calcs/rogue/Aldriana/settings.py
+++ b/shadowcraft/calcs/rogue/Aldriana/settings.py
@@ -5,8 +5,8 @@ class Settings(object):
     # Settings object for AldrianasRogueDamageCalculator.
 
     def __init__(self, cycle, response_time=.5, latency=.03, duration=300, adv_params=None,
-                 merge_damage=True, num_boss_adds=0, feint_interval=0, default_ep_stat='ap', is_day=False, is_demon=False,
-                 marked_for_death_resets=0, finisher_threshold=5):
+                 merge_damage=True, num_boss_adds=0, feint_interval=0, default_ep_stat='ap',
+                 is_day=False, is_demon=False, marked_for_death_resets=0, finisher_threshold=5):
         self.cycle = cycle
         self.response_time = response_time
         self.latency = latency
@@ -63,13 +63,13 @@ class Cycle(object):
 class AssassinationCycle(Cycle):
     _cycle_type = 'assassination'
 
-    def __init__(self, kingsbane_with_vendetta ='just', exsang_with_vendetta='just', cp_builder='mutilate'):
+    def __init__(self, kingsbane='just', exsang='just', cp_builder='mutilate', lethal_poison=''):
         self.cp_builder = cp_builder #Allowed values: 'mutilate', 'fan_of_knives'
         #Cooldown scheduling and usage settings
         #Allowed values: 'just': Use cooldown if it aligns with vendetta but don't delay usages
         #                'only': Only use cooldown with vendetta
-        self.kingsbane_with_vendetta = kingsbane_with_vendetta
-        self.exsang_with_vendetta = exsang_with_vendetta
+        self.kingsbane_with_vendetta = kingsbane
+        self.exsang_with_vendetta = exsang
 
 class OutlawCycle(Cycle):
     _cycle_type = 'outlaw'

--- a/shadowcraft/calcs/rogue/Aldriana/settings_data.py
+++ b/shadowcraft/calcs/rogue/Aldriana/settings_data.py
@@ -1,0 +1,423 @@
+# This file contains all rogue settings that are advertised to the react UI and later passed
+# into the settings object before calculation.
+
+def get_default_settings(block_name, spec, settings_data):
+    defaults = {}
+    for category in settings_data:
+        if category['name'] == block_name:
+            for option in category['items']:
+                if isinstance(option['default'], dict):
+                    defaults[option['name']] = option['default'][spec]
+                else:
+                    defaults[option['name']] = option['default']
+            break
+    return defaults
+
+rogue_settings = [
+    {
+        'spec': 'a',
+        'heading': 'Assassination Rotation Settings',
+        'name': 'rotation.assassination',
+        'items': [
+            {
+                'name': 'kingsbane',
+                'label': 'Kingsbane w/ Vendetta',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'just',
+                'options': {
+                    'just': "Use cooldown if it aligns, but don't delay usage",
+                    'only': 'Only use cooldown with Vendetta'
+                }
+            },
+            {
+                'name': 'exsang',
+                'label': 'Exsang w/ Vendetta',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'just',
+                'options': {
+                    'just': "Use cooldown if it aligns, but don't delay usage",
+                    'only': 'Only use cooldown with Vendetta'
+                }
+            },
+            {
+                'name': 'cp_builder',
+                'label': 'CP Builder',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'mutilate',
+                'options': {
+                    'mutilate': 'Mutilate',
+                    'fan_of_knives': 'Fan of Knives'
+                }
+            },
+            {
+                'name': 'lethal_poison',
+                'label': 'Lethal Poison',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'dp',
+                'options': {
+                    'dp': 'Deadly Poison',
+                    'wp': 'Wound Poison'
+                }
+            },
+        ]
+    },
+    {
+        'spec': 'Z',
+        'heading': 'Outlaw Rotation Settings',
+        'name': 'rotation.outlaw',
+        'items': [
+            {
+                'name': 'blade_flurry',
+                'label': 'Blade Flurry',
+                'description': 'Use Blade Flurry',
+                'type': 'checkbox',
+                'default': False
+            },
+            {
+                'name': 'between_the_eyes_policy',
+                'label': 'BtE Policy',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'never',
+                'options': {
+                    'shark': 'Only use with Shark',
+                    'always': 'Use BtE on cooldown',
+                    'never': 'Never use BtE',
+                }
+            },
+            {
+                'name': 'reroll_policy',
+                'label': 'RtB Reroll Policy',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'custom',
+                'options': {
+                    '1': 'Reroll single buffs',
+                    '2': 'Reroll two or fewer buffs',
+                    '3': 'Reroll three or fewer buffs',
+                    'custom': 'Custom setup per buff (see below)',
+                }
+            },
+            {
+                'name': 'jolly_roger_reroll',
+                'label': 'Jolly Roger',
+                'description': '',
+                'type': 'dropdown',
+                'default': '2',
+                'options': {
+                    '0': '0 - Never reroll combos with this buff',
+                    '1': '1 - Reroll single buff rolls of this buff',
+                    '2': '2 - Reroll double-buff rolls containing this buff',
+                    '3': '3 - Reroll triple-buff rolls containing this buff'
+                }
+            },
+            {
+                'name': 'grand_melee_reroll',
+                'label': 'Grand Melee',
+                'description': '',
+                'type': 'dropdown',
+                'default': '2',
+                'options': {
+                    '0': '0 - Never reroll combos with this buff',
+                    '1': '1 - Reroll single buff rolls of this buff',
+                    '2': '2 - Reroll double-buff rolls containing this buff',
+                    '3': '3 - Reroll triple-buff rolls containing this buff'
+                }
+            },
+            {
+                'name': 'shark_reroll',
+                'label': 'Shark-Infested Waters',
+                'description': '',
+                'type': 'dropdown',
+                'default': '2',
+                'options': {
+                    '0': '0 - Never reroll combos with this buff',
+                    '1': '1 - Reroll single buff rolls of this buff',
+                    '2': '2 - Reroll double-buff rolls containing this buff',
+                    '3': '3 - Reroll triple-buff rolls containing this buff'
+                }
+            },
+            {
+                'name': 'true_bearing_reroll',
+                'label': 'True Bearing',
+                'description': '',
+                'type': 'dropdown',
+                'default': '0',
+                'options': {
+                    '0': '0 - Never reroll combos with this buff',
+                    '1': '1 - Reroll single buff rolls of this buff',
+                    '2': '2 - Reroll double-buff rolls containing this buff',
+                    '3': '3 - Reroll triple-buff rolls containing this buff'
+                }
+            },
+            {
+                'name': 'buried_treasure_reroll',
+                'label': 'Buried Treasure',
+                'description': '',
+                'type': 'dropdown',
+                'default': '2',
+                'options': {
+                    '0': '0 - Never reroll combos with this buff',
+                    '1': '1 - Reroll single buff rolls of this buff',
+                    '2': '2 - Reroll double-buff rolls containing this buff',
+                    '3': '3 - Reroll triple-buff rolls containing this buff'
+                }
+            },
+            {
+                'name': 'broadsides_reroll',
+                'label': 'Broadsides',
+                'description': '',
+                'type': 'dropdown',
+                'default': '2',
+                'options': {
+                    '0': '0 - Never reroll combos with this buff',
+                    '1': '1 - Reroll single buff rolls of this buff',
+                    '2': '2 - Reroll double-buff rolls containing this buff',
+                    '3': '3 - Reroll triple-buff rolls containing this buff'
+                }
+            }
+        ]
+    },
+    {
+        'spec': 'b',
+        'heading': 'Subtlety Rotation Settings',
+        'name': 'rotation.subtlety',
+        'items': [
+            {
+                'name': 'cp_builder',
+                'label': 'CP Builder',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'backstab',
+                'options': {
+                    'backstab': 'Backstab',
+                    'shuriken_storm': 'Shuriken Storm',
+                }
+            },
+            {
+                'name': 'symbols_policy',
+                'label': 'SoD Policy',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'just',
+                'options': {
+                    'always': 'Use on cooldown',
+                    'just': 'Only use SoD when needed to refresh',
+                }
+            },
+            {
+                'name': 'dance_finishers_allowed',
+                'label': 'Use Finishers during Dance',
+                'description': '',
+                'type': 'checkbox',
+                'default': True
+            },
+            {
+                'name': 'positional_uptime_percent',
+                'label': 'Backstab uptime',
+                'description': 'Percentage of the fight you are behind the target (0-100). This has no effect if Gloomblade is selected as a talent.',
+                'type': 'text',
+                'default': '100'
+            },
+            {
+                'name': 'compute_cp_waste',
+                'label': 'Compute CP Waste',
+                'description': 'EXPERIMENTAL FEATURE: Compute combo point waste',
+                'type': 'checkbox',
+                'default': False
+            }
+        ]
+    },
+    {
+        'spec': 'All',
+        'heading': 'Raid Buffs',
+        'name': 'buffs',
+        'items': [
+            {
+                'name': 'flask_legion_agi',
+                'label': 'Legion Agility Flask',
+                'description': 'Flask of the Seventh Demon (1300 Agility)',
+                'type': 'checkbox',
+                'default': False
+            },
+            {
+                'name': 'short_term_haste_buff',
+                'label': '+30% Haste/40 sec',
+                'description': 'Heroism/Bloodlust/Time Warp',
+                'type': 'checkbox',
+                'default': False
+            },
+            {
+                'name': 'food_buff',
+                'label': 'Food',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'food_legion_feast_500',
+                'options': {
+                    'food_legion_crit_375': 'The Hungry Magister (375 Crit)',
+                    'food_legion_haste_375': 'Azshari Salad (375 Haste)',
+                    'food_legion_mastery_375': 'Nightborne Delicacy Platter (375 Mastery)',
+                    'food_legion_versatility_375': 'Seed-Battered Fish Plate (375 Versatility)',
+                    'food_legion_feast_500': 'Lavish Suramar Feast (500 Agility)',
+                    'food_legion_damage_3': 'Fishbrul Special (High Fire Proc)',
+                }
+            },
+            {
+                'name': 'prepot',
+                'label': 'Pre-pot',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'old_war_pot',
+                'options': {
+                    'old_war_pot': 'Potion of the Old War',
+                    'prolonged_power_pot': 'Potion of Prolonged Power',
+                    'potion_none': 'None',
+                }
+            },
+            {
+                'name': 'potion',
+                'label': 'Combat Potion',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'old_war_prepot',
+                'options': {
+                    'old_war_prepot': 'Potion of the Old War',
+                    'prolonged_power_prepot': 'Potion of Prolonged Power',
+                    'potion_none': 'None',
+                }
+            }
+        ]
+    },
+    {
+        'spec': 'All',
+        'heading': 'General Settings',
+        'name': 'general.settings',
+        'items': [
+            {
+                'name': 'is_demon',
+                'label': 'Enemy is Demon',
+                'description': 'Enables damage buff from heirloom trinket against demons',
+                'type': 'checkbox',
+                'default': False
+            },
+            {
+                'name': 'patch',
+                'label': 'Patch/Engine',
+                'description': '',
+                'type': 'dropdown',
+                'default': '7.0',
+                'options': {
+                    '7.0': '7.0',
+                    'fierys_strange_voodoo': 'fierys strange voodoo',
+                }
+            },
+            {
+                'name': 'race',
+                'label': 'Race',
+                'description': '',
+                'type': 'dropdown',
+                'default': 'human',
+                'options': {
+                    'human': 'Human',
+                    'dwarf': 'Dwarf',
+                    'orc': 'Orc',
+                    'blood_elf': 'Blood Elf',
+                    'gnome': 'Gnome',
+                    'worgen': 'Worgen',
+                    'troll': 'Troll',
+                    'night_elf': 'Night Elf',
+                    'undead': 'Undead',
+                    'goblin': 'Goblin',
+                    'pandren': 'Pandaren',
+                }
+            },
+            {
+                'name': 'is_day',
+                'label': 'Night Elf Racial',
+                'description': '',
+                'type': 'dropdown',
+                'default': False,
+                'options': {
+                    False: 'Night',
+                    True: 'Day',
+                }
+            },
+            {
+                'name': 'finisher_threshold',
+                'label': 'Finisher Threshold',
+                'description': 'Minimum CPs to use finisher',
+                'type': 'dropdown',
+                'default': {
+                    'assassination': '4',
+                    'outlaw': '5',
+                    'subtlety': '5'
+                },
+                'options': {
+                    '4': '4',
+                    '5': '5',
+                    '6': '6'
+                }
+            },
+            {
+                'name': 'level',
+                'label': 'Level',
+                'description': '',
+                'type': 'text',
+                'default': '110'
+            },
+            {
+                'name': 'duration',
+                'label': 'Fight Duration',
+                'description': '',
+                'type': 'text',
+                'default': '300'
+            },
+            {
+                'name': 'response_time',
+                'label': 'Response Time',
+                'description': '',
+                'type': 'text',
+                'default': '0.5',
+            },
+            {
+                'name': 'num_boss_adds',
+                'label': 'Number of Boss Adds',
+                'description': '',
+                'type': 'text',
+                'default': '0',
+            },
+            {
+                'name': 'marked_for_death_resets',
+                'label': 'MfD Resets Per Minute',
+                'description': '',
+                'type': 'text',
+                'default': '0',
+            }
+        ]
+    },
+    {
+        'spec': 'All',
+        'heading': 'Other',
+        'name': 'other',
+        'items': [
+            {
+                'name': 'latency',
+                'label': 'Latency',
+                'description': '',
+                'type': 'text',
+                'default': '0.03'
+            },
+            {
+                'name': 'adv_params',
+                'label': 'Advanced Parameters',
+                'description': '',
+                'type': 'text',
+                'default': ''
+            }
+        ]
+    }
+]

--- a/shadowcraft/objects/proc_data.py
+++ b/shadowcraft/objects/proc_data.py
@@ -67,54 +67,6 @@ allowed_procs = {
         'proc_rate': 1.0,
         'trigger': 'all_attacks'
     },
-    'draenic_agi_pot': {
-        'stat': 'stats',
-        'value': {'agi':1000},
-        'duration': 25,
-        'proc_name': 'Draenic Agi Potion',
-        'item_level': 100,
-        'type': 'icd',
-        'source': 'unique',
-        'icd': 0,
-        'proc_rate': 1.0,
-        'trigger': 'all_attacks'
-    },
-    'draenic_agi_prepot': {
-        'stat': 'stats',
-        'value': {'agi':1000},
-        'duration': 23,
-        'proc_name': 'Draenic Agi Prepot',
-        'item_level': 100,
-        'type': 'icd',
-        'source': 'unique',
-        'icd': 0,
-        'proc_rate': 1.0,
-        'trigger': 'all_attacks'
-    },
-    'virmens_bite': {
-        'stat': 'stats',
-        'value': {'agi':456},
-        'duration': 25,
-        'proc_name': 'Virmens Bite',
-        'item_level': 90,
-        'type': 'icd',
-        'source': 'unique',
-        'icd': 0,
-        'proc_rate': 1.0,
-        'trigger': 'all_attacks'
-    },
-    'virmens_bite_prepot': {
-        'stat': 'stats',
-        'value': {'agi':456},
-        'duration': 23,
-        'proc_name': 'Virmens Bite',
-        'item_level': 90,
-        'type': 'icd',
-        'source': 'unique',
-        'icd': 0,
-        'proc_rate': 1.0,
-        'trigger': 'all_attacks'
-    },
     #racials
     'touch_of_the_grave': {
         'stat': 'spell_damage',

--- a/shadowcraft/objects/procs.py
+++ b/shadowcraft/objects/procs.py
@@ -216,7 +216,6 @@ class ProcsList(object):
                     procs.append(proc)
                 elif proc.stat in ('stats', 'highest', 'random') and stat in proc.value:
                     procs.append(proc)
-
         return procs
 
     def get_all_damage_procs(self):


### PR DESCRIPTION
In compliance with the settings data the new UI uses, introduce settings_data.py with all the settings the UI displays for us. The default values are used automatically and the Settings constructors now unpack differences from a dictionary.

Notes:
- Level and Race settings are just offered to the UI and supposed to be set from there, but not used internally in the engine.
- Engine version picker should probably be moved to the UI later.
- Buffs are also only advertised but not used as defaults because those are not "settings" in the engine.